### PR TITLE
update key bindings, add sprinting, add hopping

### DIFF
--- a/Scripts/kineplayer.gd
+++ b/Scripts/kineplayer.gd
@@ -3,7 +3,6 @@ extends CharacterBody2D
 @onready var dragline = get_parent().get_node("dragline")
 const SPEED = 600.0
 const JUMP_VELOCITY = -400.0
-const HOP_VELOCITY = -400.0
 var friction = 0
 var mouse_start := Vector2.ZERO # starting point of dragline
 var mouse_fin := Vector2.ZERO # ending point of dragline
@@ -36,8 +35,6 @@ func _physics_process(delta):
 		var sprint = 1
 		if Input.is_action_pressed("sprint"):
 			sprint = 1.5
-		if Input.is_action_just_pressed("hop"):
-			velocity.y = HOP_VELOCITY * sprint
 		if direction:
 			direction /= abs(direction)
 			velocity.x = direction * SPEED * sprint

--- a/Scripts/kineplayer.gd
+++ b/Scripts/kineplayer.gd
@@ -3,6 +3,7 @@ extends CharacterBody2D
 @onready var dragline = get_parent().get_node("dragline")
 const SPEED = 600.0
 const JUMP_VELOCITY = -400.0
+const HOP_VELOCITY = -400.0
 var friction = 0
 var mouse_start := Vector2.ZERO # starting point of dragline
 var mouse_fin := Vector2.ZERO # ending point of dragline
@@ -28,8 +29,18 @@ func _physics_process(delta):
 	
 	if is_on_floor():
 		var direction = Input.get_axis("ui_left", "ui_right")
+		if Input.is_action_pressed("left"):
+			direction -= 1
+		if Input.is_action_pressed("right"):
+			direction += 1
+		var sprint = 1
+		if Input.is_action_pressed("sprint"):
+			sprint = 1.5
+		if Input.is_action_just_pressed("hop"):
+			velocity.y = HOP_VELOCITY * sprint
 		if direction:
-			velocity.x = direction * SPEED
+			direction /= abs(direction)
+			velocity.x = direction * SPEED * sprint
 		else:
 			velocity.x = move_toward(velocity.x, 0 , SPEED*friction)
 
@@ -43,7 +54,6 @@ func _physics_process(delta):
 		else:
 			velocity = Vector2(0,30)
 		move_and_slide()
-		pass
 		
 #func _on_wall_entered():
 	

--- a/project.godot
+++ b/project.godot
@@ -36,7 +36,29 @@ c={
 }
 hold={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194326,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+sprint={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194328,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+]
+}
+right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+]
+}
+hop={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
Updates:

- Allow left/right axis motion using the "a" and "d" keys as well as "arrow-left" and "arrow-right"
- Normalized directions to prevent issues when pressing "a"/"d" at the same time or at the same time as the arrow keys
- Allow sprinting while holding "w" or "alt"
- Allow grabbing with "ctrl" in addition to "e"
- Allow short hops (useless but cute) when pressing "space"